### PR TITLE
SUP-2392 - Remove WebVTT uploading support in KMC

### DIFF
--- a/KedLib/src/com/kaltura/edw/view/captions/CaptionsTable.mxml
+++ b/KedLib/src/com/kaltura/edw/view/captions/CaptionsTable.mxml
@@ -55,12 +55,7 @@
 			private static const SRT_EXT:String = "*.srt";
 			
 			/**
-			 * file extension for WebVTT format
-			 * */
-			private static const WEBVTT_EXT:String = "*.vtt";
 
-			
-			
 			
 			/**
 			 * tab controller
@@ -158,9 +153,6 @@
 					case KalturaCaptionType.DFXP:
 						fileName += '.xml';
 						break;
-					case KalturaCaptionType.WEBVTT:
-						fileName += '.vtt';
-						break;
 				}
 				// download asset:
 				var fr:FileReference = new FileReference();
@@ -225,14 +217,11 @@
 						case KalturaCaptionType.DFXP:
 							fileTypes = DFXP_EXT;
 							break;
-						case KalturaCaptionType.WEBVTT:
-							fileTypes = WEBVTT_EXT;
-							break;
 					}
 				}
 				else {
 					// new caption - allow all types
-					fileTypes = SRT_EXT + ';' + DFXP_EXT + ';' + WEBVTT_EXT;
+					fileTypes = SRT_EXT + ';' + DFXP_EXT;
 				}
 				
 				_activeCaption = caption;
@@ -250,9 +239,6 @@
 				switch (fileExtension.toLowerCase()) {
 					case 'xml':
 						_activeCaption.caption.format = KalturaCaptionType.DFXP;
-						break;
-					case 'vtt': 
-						_activeCaption.caption.format = KalturaCaptionType.WEBVTT;
 						break;
 					default:
 						_activeCaption.caption.format = KalturaCaptionType.SRT;

--- a/KedLib/src/com/kaltura/edw/view/ir/captions/FileTypeRenderer.mxml
+++ b/KedLib/src/com/kaltura/edw/view/ir/captions/FileTypeRenderer.mxml
@@ -12,8 +12,7 @@
 			[Bindable]
 			private static var captionTypes:Array = [
 				{label:ResourceManager.getInstance().getString('drilldown','srtLabel') , value:KalturaCaptionType.SRT},
-				{label:ResourceManager.getInstance().getString('drilldown','dfxpLabel'), value:KalturaCaptionType.DFXP},
-				{label:ResourceManager.getInstance().getString('drilldown','vttLabel'), value:KalturaCaptionType.WEBVTT}];
+				{label:ResourceManager.getInstance().getString('drilldown','dfxpLabel'), value:KalturaCaptionType.DFXP}];
 			
 			
 //			override public function set data(value:Object):void {


### PR DESCRIPTION
Per this change: https://github.com/kaltura/server/commit/32e51df0cae3d64ded79953dc040cba57517fd78, we do not longer support uploading WebVTT captions via the API/server. Hence, when uploading via KMC - Internal Server Error is received. 
So we need to remove the option to upload via the KMC as well.
